### PR TITLE
Wait client leave before raise event channel left

### DIFF
--- a/Assets/WebGLTemplates/AgoraTemplate/AgoraWebSDK/libs/clientmanager.js
+++ b/Assets/WebGLTemplates/AgoraTemplate/AgoraWebSDK/libs/clientmanager.js
@@ -280,10 +280,10 @@ class ClientManager {
     // remove remote users and player views
     remoteUsers = {};
 
-    event_manager.raiseOnLeaveChannel();
-
     // leave the channel
     await this.client.leave();
+    event_manager.raiseOnLeaveChannel();
+
     this._inChannel = false;
   }
 


### PR DESCRIPTION
Hello,

I allow myself to make you this PR in order to correct the fact that the event channel left is called too early on the Unity side.