### PR TITLE
Fix issue #226 (screenshare color in linear space)

### DIFF
--- a/Assets/AgoraEngine/Plugins/WebGL/AgoraWebGLSDK.jslib
+++ b/Assets/AgoraEngine/Plugins/WebGL/AgoraWebGLSDK.jslib
@@ -35,7 +35,7 @@ var LibraryAgoraWebGLSDK = {
     }
     return false;
   },
-  updateLocalTexture: function (tex) {
+  updateLocalTexture: function (tex, isLinearColor) {
     var lVid = undefined; // set null initially
     if (localTracks != undefined) {
       if (localTracks.videoTrack != undefined) {
@@ -82,10 +82,12 @@ var LibraryAgoraWebGLSDK = {
       GLctx.TEXTURE_MIN_FILTER,
       GLctx.LINEAR
     );
+    var internalformat = GLctx.RGBA;
+    if (isLinearColor) internalformat = GLctx.SRGB8_ALPHA8;
     GLctx.texImage2D(
       GLctx.TEXTURE_2D,
       0,
-      GLctx.RGBA,
+      internalformat,
       GLctx.RGBA,
       GLctx.UNSIGNED_BYTE,
       v
@@ -110,7 +112,7 @@ var LibraryAgoraWebGLSDK = {
     return 1;
   }, 
 
-  updateRemoteTexture: function (userId, tex) {
+  updateRemoteTexture: function (userId, tex, isLinearColor) {
     var ch_userId = Pointer_stringify(userId);
 
     var lVid = undefined; // set null initially
@@ -160,10 +162,12 @@ var LibraryAgoraWebGLSDK = {
         GLctx.TEXTURE_MIN_FILTER,
         GLctx.LINEAR
       );
+      var internalformat = GLctx.RGBA;
+      if (isLinearColor) internalformat = GLctx.SRGB8_ALPHA8;
       GLctx.texImage2D(
         GLctx.TEXTURE_2D,
         0,
-        GLctx.RGBA,
+        internalformat,
         GLctx.RGBA,
         GLctx.UNSIGNED_BYTE,
         v
@@ -217,6 +221,9 @@ var LibraryAgoraWebGLSDK = {
 
     // v.lastUpdateTextureTime = v.currentTime;
 
+    var internalformat = GLctx.RGBA;
+    if (isLinearColor) internalformat = GLctx.SRGB8_ALPHA8;
+
     if ( 1 
       // v.previousUploadedWidth != v.videoWidth ||
       // v.previousUploadedHeight != v.videoHeight
@@ -244,7 +251,7 @@ var LibraryAgoraWebGLSDK = {
       GLctx.texImage2D(
         GLctx.TEXTURE_2D,
         0,
-        GLctx.RGBA,
+        internalformat,
         GLctx.RGBA,
         GLctx.UNSIGNED_BYTE,
         v
@@ -256,7 +263,7 @@ var LibraryAgoraWebGLSDK = {
       GLctx.texImage2D(
         GLctx.TEXTURE_2D,
         0,
-        GLctx.RGBA,
+        internalformat,
         GLctx.RGBA,
         GLctx.UNSIGNED_BYTE,
         v

--- a/Assets/AgoraEngine/Scripts/AgoraGamingSDK/native/IAgoraGamingRtcEngineNative.cs
+++ b/Assets/AgoraEngine/Scripts/AgoraGamingSDK/native/IAgoraGamingRtcEngineNative.cs
@@ -1084,7 +1084,7 @@ namespace agora_gaming_rtc
         protected static extern bool isLocalVideoReady();
 
         [DllImport(MyLibName, CharSet = CharSet.Ansi)]
-        protected static extern void updateLocalTexture(IntPtr texture);
+        protected static extern void updateLocalTexture(IntPtr texture, bool isLinearColor);
         [DllImport(MyLibName, CharSet = CharSet.Ansi)]
         protected static extern int createRemoteTexture(string userId);
 
@@ -1094,10 +1094,10 @@ namespace agora_gaming_rtc
         protected static extern bool isRemoteVideoReady_MC(string channelId, string videoID);
 
         [DllImport(MyLibName, CharSet = CharSet.Ansi)]
-        public static extern void updateRemoteTexture(string videoID, IntPtr texture);
+        public static extern void updateRemoteTexture(string videoID, IntPtr texture, bool isLinearColor);
 
         [DllImport(MyLibName, CharSet = CharSet.Ansi)]
-        public static extern void updateRemoteTexture_MC(string channel, string videoID, IntPtr texture);
+        public static extern void updateRemoteTexture_MC(string channel, string videoID, IntPtr texture, bool isLinearColor);
 
         [DllImport(MyLibName, CharSet = CharSet.Ansi)]
         public static extern void setCurrentChannel_WGL(string channelId);

--- a/Assets/AgoraEngine/Scripts/AgoraWebGLEventHandler.cs
+++ b/Assets/AgoraEngine/Scripts/AgoraWebGLEventHandler.cs
@@ -1517,7 +1517,7 @@ namespace agora_gaming_rtc
                 return;
             if (tex != null)
             {
-                updateLocalTexture(tex.GetNativeTexturePtr());
+                updateLocalTexture(tex.GetNativeTexturePtr(), QualitySettings.activeColorSpace == ColorSpace.Linear);
             }
         }
 
@@ -1525,7 +1525,9 @@ namespace agora_gaming_rtc
         {
             if (!isRemoteVideoReady("" + uid))
                 return;
-            updateRemoteTexture("" + uid, tex.GetNativeTexturePtr());
+            updateRemoteTexture(
+                "" + uid, tex.GetNativeTexturePtr(),
+                QualitySettings.activeColorSpace == ColorSpace.Linear);
         }
 
     }

--- a/Assets/AgoraEngine/Scripts/InSurfaceRenderer.cs
+++ b/Assets/AgoraEngine/Scripts/InSurfaceRenderer.cs
@@ -16,7 +16,7 @@ namespace agora_gaming_rtc
                 return;
             if (tex != null)
             {
-                updateLocalTexture(tex.GetNativeTexturePtr());
+                updateLocalTexture(tex.GetNativeTexturePtr(), QualitySettings.activeColorSpace == ColorSpace.Linear);
             }
         }
 
@@ -38,7 +38,9 @@ namespace agora_gaming_rtc
         {
             if (isRemoteVideoReady_MC(channel, uid + ""))
             {
-                updateRemoteTexture_MC(channel, "" + uid, tex.GetNativeTexturePtr());
+                updateRemoteTexture_MC(
+                    channel, "" + uid, tex.GetNativeTexturePtr(),
+                    QualitySettings.activeColorSpace == ColorSpace.Linear);
             }
         }
 
@@ -47,7 +49,9 @@ namespace agora_gaming_rtc
         {
             if (!isRemoteVideoReady(""+uid))
                 return;
-            updateRemoteTexture(""+uid, tex.GetNativeTexturePtr());
+            updateRemoteTexture(
+                "" + uid, tex.GetNativeTexturePtr(),
+                QualitySettings.activeColorSpace == ColorSpace.Linear);
         }
 
         // initialize remote video surface


### PR DESCRIPTION
The pull request is to fix issue #226 : The color of shared screen displayed will become brighter than the original screen if the color space (Player Settings -> Other Settings -> Color Space) is set to linear, 

This is because in linear color space, screen texture is sent in sRGB but received as RGB. It seems not possible to set the texture being sent to be RGB (may be it is done in the blackbox of Agora SDK), so I think the only available fix is to convert sRGB to RGB on the receiving side.

The issue only occurs when running in browser. It doesn't occur when running in Editor since the receiving source code of Editor case and browser case are different.

When running in Editor, the texture is loaded into CPU memory by Unity API. Therefore, sRGB->RGB conversion should be automatically peformed by Unity when the texture is sent to shader.

https://github.com/AgoraIO-Community/Agora_Unity_WebGL/blob/63a037f159e71fe24e274a2a15d7bac2dcd167f4/Assets/AgoraEngine/Scripts/AgoraGamingSDK/videoRender/VideoSurface.cs#L237